### PR TITLE
Fix iterm2 template

### DIFF
--- a/templates/iterm.dot
+++ b/templates/iterm.dot
@@ -1,4 +1,4 @@
-xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>


### PR DESCRIPTION
Adds a missing `<?` at beginning of file
