### PR TITLE
fix bold text in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -82,7 +82,7 @@ fs.writeFile('~/config.itermcolors', iterm);
 - `konsole`
 - Export
 
-**Linux console
+**Linux console**
 
 - `linux`
 - Export


### PR DESCRIPTION
`Linux console` in readme.md is not in bold.