### PR TITLE
Add supports for urxvt

### DIFF
--- a/lib/formats/urxvt.js
+++ b/lib/formats/urxvt.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var _ = require('lodash');
+var fs = require('fs');
+var createExporter = require('../exporter');
+
+var template = fs.readFileSync(__dirname + '/../../templates/urxvt.dot', 'utf8');
+
+module.exports = {
+
+  export: createExporter(template, _.partialRight(_.mapValues, function (color) {
+    return color.toHex();
+  }))
+
+};

--- a/templates/urxvt.dot
+++ b/templates/urxvt.dot
@@ -1,0 +1,36 @@
+! special
+URxvt.foreground:   {{=c.foreground}}
+URxvt.background:   {{=c.background}}
+URxvt.cursorColor:  {{=c.foreground}}
+
+! black
+URxvt.color0:       {{=c[0]}}
+URxvt.color8:       {{=c[8]}}
+
+! red
+URxvt.color1:       {{=c[1]}}
+URxvt.color9:       {{=c[9]}}
+
+! green
+URxvt.color2:       {{=c[2]}}
+URxvt.color10:      {{=c[10]}}
+
+! yellow
+URxvt.color3:       {{=c[3]}}
+URxvt.color11:      {{=c[11]}}
+
+! blue
+URxvt.color4:       {{=c[4]}}
+URxvt.color12:      {{=c[12]}}
+
+! magenta
+URxvt.color5:       {{=c[5]}}
+URxvt.color13:      {{=c[13]}}
+
+! cyan
+URxvt.color6:       {{=c[6]}}
+URxvt.color14:      {{=c[14]}}
+
+! white
+URxvt.color7:       {{=c[7]}}
+URxvt.color15:      {{=c[15]}}


### PR DESCRIPTION
Not very usefull since Xressources format is supported by urxvt. But when you want a scheme only for urxvt, it saves you an extra step of modification.

No tested it yet, I don't know how to use React. 