### PR TITLE
Fix for visible selection in iTerm2

### DIFF
--- a/templates/iterm.dot
+++ b/templates/iterm.dot
@@ -249,11 +249,11 @@
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Blue Component</key>
-		<real>{{=c.background[2]}}</real>
+		<real>{{=c[8][2]}}</real>
 		<key>Green Component</key>
-		<real>{{=c.background[1]}}</real>
+		<real>{{=c[8][1]}}</real>
 		<key>Red Component</key>
-		<real>{{=c.background[0]}}</real>
+		<real>{{=c[8][0]}}</real>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Selection was the same colour as the background, this way it's the
bright black color, which should always be a secondary bright color or
actually black in a bright version