### PR TITLE
Fix xfce4-terminal template

### DIFF
--- a/templates/xfce.dot
+++ b/templates/xfce.dot
@@ -1,4 +1,4 @@
-[Configuration]
+[Scheme]
 ColorCursor={{=c.foreground}}
 ColorForeground={{=c.foreground}}
 ColorBackground={{=c.background}}


### PR DESCRIPTION
It requires a `[Scheme]` section instead of `[Configuration]`