### PR TITLE
Add support for outputting to windows-terminal JSON

### DIFF
--- a/examples/windows-terminal.txt
+++ b/examples/windows-terminal.txt
@@ -1,0 +1,24 @@
+{
+  "name":"terminal.sexy",
+
+  "foreground"   : "#000000",
+  "background"   : "#ffffff",
+
+  "black"        : "#000000",
+  "red"          : "#cc0403",
+  "green"        : "#19cb00",
+  "yellow"       : "#cecb00",
+  "blue"         : "#001cd1",
+  "purple"       : "#cb1ed1",
+  "cyan"         : "#0dcdcd",
+  "white"        : "#e5e5e5",
+
+  "brightBlack"  : "#4d4d4d",
+  "brightRed"    : "#3e0605",
+  "brightGreen"  : "#23fd00",
+  "brightYellow" : "#fffd00",
+  "brightBlue"   : "#0026ff",
+  "brightPurple" : "#fd28ff",
+  "brightCyan"   : "#14ffff",
+  "brightWhite"  : "#ffffff"
+}

--- a/lib/formats/windows-terminal.js
+++ b/lib/formats/windows-terminal.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var _ = require('lodash');
+var fs = require('fs');
+var createExporter = require('../exporter');
+
+var template = fs.readFileSync(__dirname + '/../../templates/windows-terminal.dot', 'utf8');
+
+module.exports = {
+
+  export: createExporter(template, _.partialRight(_.mapValues, function (color) {
+    return color.toHex();
+  }))
+
+};

--- a/templates/windows-terminal.dot
+++ b/templates/windows-terminal.dot
@@ -1,0 +1,24 @@
+{
+  "name":"terminal.sexy",
+
+  "foreground"   : "{{=c.background}}",
+  "background"   : "{{=c.foreground}}",
+
+  "black"        : "{{=c[0]}}",
+  "red"          : "{{=c[1]}}",
+  "green"        : "{{=c[2]}}",
+  "yellow"       : "{{=c[3]}}",
+  "blue"         : "{{=c[4]}}",
+  "purple"       : "{{=c[5]}}",
+  "cyan"         : "{{=c[6]}}",
+  "white"        : "{{=c[7]}}",
+
+  "brightBlack"  : "{{=c[8]}}",
+  "brightRed"    : "{{=c[9]}}",
+  "brightGreen"  : "{{=c[10]}}",
+  "brightYellow" : "{{=c[11]}}",
+  "brightBlue"   : "{{=c[12]}}",
+  "brightPurple" : "{{=c[13]}}",
+  "brightCyan"   : "{{=c[14]}}",
+  "brightWhite"  : "{{=c[15]}}"
+}

--- a/test/formats/windows-terminal.js
+++ b/test/formats/windows-terminal.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var _ = require('lodash');
+var fs = require('fs');
+var wt = require('../../lib/formats/windows-terminal');
+var same = require('../utils/same');
+var defaults = require('../../lib/formats/defaults');
+
+describe('formats/wt', function () {
+
+  var COLORS = defaults.colors;
+  var OUTPUT = fs.readFileSync(__dirname + '/../../examples/windows-terminal.txt', 'utf8');
+
+  describe('.export', function () {
+
+    it('should export as windows-terminal', function () {
+      var actual = wt.export(COLORS);
+      same(actual, OUTPUT);
+    });
+
+  });
+
+});


### PR DESCRIPTION
Adds a new .dot file and test for writing colorscheme json for windows terminal.  Mostly copied from st